### PR TITLE
feat: add file history backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Aird is a modern, lightweight, and fast web-based file browser, editor, and stre
   - Delete files and directories (can be disabled)
   - Rename files and directories (can be disabled)
   - **NEW:** In-browser file editing with syntax highlighting and line numbers
+  - Automatic file history with timestamped backups
 - **File Sharing:** Create secure, temporary public links for files and directories
   - Select multiple files and folders to share together
   - Generate unique, time-limited shareable URLs
@@ -325,7 +326,6 @@ This project is licensed under a **Custom License** that prohibits commercial us
 - **Theme Support:** Dark mode and customizable themes
 
 ### 🚀 Advanced Features (Planned)
-- **File History:** Version tracking and backup features
 - **API Integration:** RESTful API for external integrations
 - **Plugin System:** Extensible architecture for custom features
 

--- a/aird/templates/admin.html
+++ b/aird/templates/admin.html
@@ -37,6 +37,10 @@
             <input type="checkbox" name="file_edit" {% if features.get('file_edit') %}checked{% end %}>
             Enable File Edit
         </label><br>
+        <label>
+            <input type="checkbox" name="file_history" {% if features.get('file_history') %}checked{% end %}>
+            Enable File History
+        </label><br>
         <br>
         <input type="submit" value="Save">
     </form>

--- a/tests/test_file_history.py
+++ b/tests/test_file_history.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from aird import main
+
+
+def test_backup_file(tmp_path):
+    main.ROOT_DIR = tmp_path
+    main.FEATURE_FLAGS["file_history"] = True
+
+    target = tmp_path / "example.txt"
+    target.write_text("hello")
+
+    main.backup_file("example.txt")
+
+    history_dir = tmp_path / main.HISTORY_DIR_NAME
+    backups = list(history_dir.glob("example.txt.*"))
+    assert backups, "Backup was not created"


### PR DESCRIPTION
## Summary
- backup files before editing and store timestamped copies
- allow administrators to toggle file history feature
- document file history capability and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896443f3fc8832a808bb22201cf916d